### PR TITLE
fix: buffer/map type extension

### DIFF
--- a/proxywasm/buffer.go
+++ b/proxywasm/buffer.go
@@ -49,10 +49,6 @@ func GetBuffer(instance common.WasmInstance, bufferType BufferType) common.IoBuf
 }
 
 func ProxyGetBufferBytes(instance common.WasmInstance, bufferType int32, start int32, length int32, returnBufferData int32, returnBufferSize int32) int32 {
-	if BufferType(bufferType) > BufferTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	buf := GetBuffer(instance, BufferType(bufferType))
 	if buf == nil {
 		return WasmResultNotFound.Int32()
@@ -90,10 +86,6 @@ func ProxyGetBufferBytes(instance common.WasmInstance, bufferType int32, start i
 }
 
 func ProxySetBufferBytes(instance common.WasmInstance, bufferType int32, start int32, length int32, dataPtr int32, dataSize int32) int32 {
-	if BufferType(bufferType) > BufferTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	buf := GetBuffer(instance, BufferType(bufferType))
 	if buf == nil {
 		return WasmResultNotFound.Int32()

--- a/proxywasm/header.go
+++ b/proxywasm/header.go
@@ -47,10 +47,6 @@ func GetMap(instance common.WasmInstance, mapType MapType) common.HeaderMap {
 }
 
 func ProxyGetHeaderMapPairs(instance common.WasmInstance, mapType int32, returnDataPtr int32, returnDataSize int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	header := GetMap(instance, MapType(mapType))
 	if header == nil {
 		return WasmResultNotFound.Int32()
@@ -109,10 +105,6 @@ func ProxyGetHeaderMapPairs(instance common.WasmInstance, mapType int32, returnD
 }
 
 func ProxySetHeaderMapPairs(instance common.WasmInstance, mapType int32, ptr int32, size int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	headerMap := GetMap(instance, MapType(mapType))
 	if headerMap == nil {
 		return WasmResultNotFound.Int32()
@@ -133,10 +125,6 @@ func ProxySetHeaderMapPairs(instance common.WasmInstance, mapType int32, ptr int
 }
 
 func ProxyGetHeaderMapValue(instance common.WasmInstance, mapType int32, keyDataPtr int32, keySize int32, valueDataPtr int32, valueSize int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	headerMap := GetMap(instance, MapType(mapType))
 	if headerMap == nil {
 		return WasmResultNotFound.Int32()
@@ -159,10 +147,6 @@ func ProxyGetHeaderMapValue(instance common.WasmInstance, mapType int32, keyData
 }
 
 func ProxyReplaceHeaderMapValue(instance common.WasmInstance, mapType int32, keyDataPtr int32, keySize int32, valueDataPtr int32, valueSize int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	headerMap := GetMap(instance, MapType(mapType))
 	if headerMap == nil {
 		return WasmResultNotFound.Int32()
@@ -190,10 +174,6 @@ func ProxyReplaceHeaderMapValue(instance common.WasmInstance, mapType int32, key
 }
 
 func ProxyAddHeaderMapValue(instance common.WasmInstance, mapType int32, keyDataPtr int32, keySize int32, valueDataPtr int32, valueSize int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	headerMap := GetMap(instance, MapType(mapType))
 	if headerMap == nil {
 		return WasmResultNotFound.Int32()
@@ -218,10 +198,6 @@ func ProxyAddHeaderMapValue(instance common.WasmInstance, mapType int32, keyData
 }
 
 func ProxyRemoveHeaderMapValue(instance common.WasmInstance, mapType int32, keyDataPtr int32, keySize int32) int32 {
-	if MapType(mapType) > MapTypeMax {
-		return WasmResultBadArgument.Int32()
-	}
-
 	headerMap := GetMap(instance, MapType(mapType))
 	if headerMap == nil {
 		return WasmResultNotFound.Int32()

--- a/proxywasm/types.go
+++ b/proxywasm/types.go
@@ -35,7 +35,6 @@ const (
 	MapTypeGrpcReceiveTrailingMetadata MapType = 5
 	MapTypeHttpCallResponseHeaders     MapType = 6
 	MapTypeHttpCallResponseTrailers    MapType = 7
-	MapTypeMax                         MapType = 7
 )
 
 type BufferType int32
@@ -50,7 +49,6 @@ const (
 	BufferTypeVmConfiguration      BufferType = 6
 	BufferTypePluginConfiguration  BufferType = 7
 	BufferTypeCallData             BufferType = 8
-	BufferTypeMax                  BufferType = 8
 )
 
 type MetricType int32


### PR DESCRIPTION
issuse: https://github.com/mosn/proxy-wasm-go-host/issues/1

do not check BufferTypeMax so that get/setBuffers can work with custom buffer