### PR TITLE
Adds a build matrix for supported Go versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,6 +36,29 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    # A matrix proves the supported range of Go versions work. This must always
+    # include the floor Go version policy of Mosn and the current Go version.
+    # Mosn's floor Go version for libraries is two behind current, e.g. if Go
+    # supports 1.19 and 1.20, Mosn libraries must work on 1.18, 1.19 and 1.20.
+    #
+    # A floor version is required to ensure Mosn can receive security patches.
+    # Without one, dependencies become locked to an old version of Go, which
+    # itself receives no security patch updates.
+    #
+    # Mosn's binary is built with Go's floor version, e.g. if Go supports 1.19
+    # and 1.20, Mosn will build any downloadable executables with 1.19.
+    #
+    # Even if mosn works with a Go version below its supported floor, users
+    # must not depend on this. Mosn and its library dependencies are free to
+    # use features in the supported floor Go version at any time. This remains
+    # true even if mosn library dependencies are not eagerly updated.
+    strategy:
+      matrix:
+        go-version:
+          - "1.19"  # Current Go version
+          - "1.18"
+          - "1.17"  # Floor Go version of Mosn == current - 2
+
     steps:
       - name: Check out code
         uses: actions/checkout@v3
@@ -43,7 +66,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: ${{ matrix.go-version }}
           cache: true
 
       - name: Test

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mosn.io/proxy-wasm-go-host
 
-go 1.18
+go 1.17
 
 require (
 	github.com/stretchr/testify v1.7.1


### PR DESCRIPTION
This also lowers go.mod to 1.17 accordingly

cc @taoyuanyuan @antJack

See mosn/mosn#2153