### PR TITLE
Adds Makefile for formatting code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+gofumpt := mvdan.cc/gofumpt@v0.4.0
+gosimports := github.com/rinchsan/gosimports/cmd/gosimports@v0.3.4
+
+.PHONY: format
+format:
+	@go run $(gofumpt) -l -w .
+	@go run $(gosimports) -local mosn.io/proxy-wasm-go-host/ -w $(shell find . -name '*.go' -type f)

--- a/example/main.go
+++ b/example/main.go
@@ -26,7 +26,7 @@ import (
 	"sync/atomic"
 
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
-	"mosn.io/proxy-wasm-go-host/proxywasm/v1"
+	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
 	"mosn.io/proxy-wasm-go-host/wasmer"
 )
 

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -27,17 +27,17 @@ import (
 	"sync"
 	"sync/atomic"
 
-	importsv1 "mosn.io/proxy-wasm-go-host/internal/imports/v1"
-	importsv2 "mosn.io/proxy-wasm-go-host/internal/imports/v2"
-	"mosn.io/proxy-wasm-go-host/proxywasm/common"
-	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
-	v2 "mosn.io/proxy-wasm-go-host/proxywasm/v2"
-
 	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
 	"mosn.io/mosn/pkg/log"
 	"mosn.io/mosn/pkg/types"
 	"mosn.io/mosn/pkg/wasm/abi"
 	"mosn.io/pkg/utils"
+
+	importsv1 "mosn.io/proxy-wasm-go-host/internal/imports/v1"
+	importsv2 "mosn.io/proxy-wasm-go-host/internal/imports/v2"
+	"mosn.io/proxy-wasm-go-host/proxywasm/common"
+	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
+	v2 "mosn.io/proxy-wasm-go-host/proxywasm/v2"
 )
 
 var (

--- a/wasmer/instance_test.go
+++ b/wasmer/instance_test.go
@@ -19,7 +19,6 @@ package wasmer
 
 import (
 	"context"
-	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
 	"reflect"
 	"testing"
 	"time"
@@ -29,6 +28,8 @@ import (
 	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
 	"mosn.io/mosn/pkg/mock"
 	"mosn.io/mosn/pkg/types"
+
+	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
 )
 
 func TestRegisterImports(t *testing.T) {

--- a/wasmer/vm.go
+++ b/wasmer/vm.go
@@ -20,6 +20,7 @@ package wasmer
 import (
 	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
 	"mosn.io/mosn/pkg/log"
+
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 )
 


### PR DESCRIPTION
`make format` will correct imports and format better than goimports and gofmt.
