### PR TITLE
Adds wazero implementation and makes wasmer gated by build flag

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build
         run: go build ./...
 
+      - name: Build (wasmer)
+        run: go build -tags='wasmer' ./...
+
   test:
     runs-on: ubuntu-latest
     # A matrix proves the supported range of Go versions work. This must always
@@ -71,3 +74,6 @@ jobs:
 
       - name: Test
         run: go test -v ./...
+
+      - name: Test (wasmer)
+        run: go test -tags='wasmer' -v ./...

--- a/example/main.go
+++ b/example/main.go
@@ -27,7 +27,7 @@ import (
 
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
-	"mosn.io/proxy-wasm-go-host/wasmer"
+	"mosn.io/proxy-wasm-go-host/wazero"
 )
 
 var (
@@ -129,7 +129,7 @@ func getWasmContext() *v1.ABIContext {
 			log.Panicln(err)
 		}
 
-		instance := wasmer.NewInstanceFromBinary(guest)
+		instance := wazero.NewInstanceFromBinary(guest)
 
 		// create ABI context
 		wasmCtx = &v1.ABIContext{

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a
+	github.com/tetratelabs/wazero v1.0.0-pre.3.0.20221109072710-7e3cda868088
 	github.com/wasmerio/wasmer-go v1.0.4
 	mosn.io/mosn v1.2.0
 	mosn.io/pkg v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a h1:P0R3+CTAT7daT8ig5gh9GEd/eDQ5md1xl4pkYMcwOqg=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
+github.com/tetratelabs/wazero v1.0.0-pre.3.0.20221109072710-7e3cda868088 h1:0ZYozoLl9vdMbRucTGv8CL9hiHPDh2zn2b9HPtEFOoo=
+github.com/tetratelabs/wazero v1.0.0-pre.3.0.20221109072710-7e3cda868088/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/internal/e2e/benchmark_test.go
+++ b/internal/e2e/benchmark_test.go
@@ -15,20 +15,26 @@
  * limitations under the License.
  */
 
-package wasm
+package e2e
 
 import (
 	_ "embed"
 	"testing"
 
+	"mosn.io/pkg/log"
+
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
 	v2 "mosn.io/proxy-wasm-go-host/proxywasm/v2"
-	"mosn.io/proxy-wasm-go-host/wasmer"
+	"mosn.io/proxy-wasm-go-host/wazero"
 )
 
-func BenchmarkStartABIContextV1_wasmer(b *testing.B) {
-	benchmarkStartABIContextV1(b, wasmer.NewInstanceFromBinary)
+func init() {
+	log.DefaultLogger.SetLogLevel(log.ERROR)
+}
+
+func BenchmarkStartABIContextV1_wazero(b *testing.B) {
+	benchmarkStartABIContextV1(b, wazero.NewInstanceFromBinary)
 }
 
 func benchmarkStartABIContextV1(b *testing.B, newInstance func([]byte) common.WasmInstance) {
@@ -41,8 +47,8 @@ func benchmarkStartABIContextV1(b *testing.B, newInstance func([]byte) common.Wa
 	}
 }
 
-func BenchmarkAddRequestHeaderV1_wasmer(b *testing.B) {
-	benchmarkAddRequestHeaderV1(b, wasmer.NewInstanceFromBinary)
+func BenchmarkAddRequestHeaderV1_wazero(b *testing.B) {
+	benchmarkAddRequestHeaderV1(b, wazero.NewInstanceFromBinary)
 }
 
 func benchmarkAddRequestHeaderV1(b *testing.B, newInstance func([]byte) common.WasmInstance) {
@@ -92,8 +98,8 @@ func benchmarkV1(b *testing.B, instance common.WasmInstance, testV1 func(wasmCtx
 	}
 }
 
-func BenchmarkStartABIContextV2_wasmer(b *testing.B) {
-	benchmarkStartABIContextV2(b, wasmer.NewInstanceFromBinary)
+func BenchmarkStartABIContextV2_wazero(b *testing.B) {
+	benchmarkStartABIContextV2(b, wazero.NewInstanceFromBinary)
 }
 
 func benchmarkStartABIContextV2(b *testing.B, newInstance func([]byte) common.WasmInstance) {
@@ -106,8 +112,8 @@ func benchmarkStartABIContextV2(b *testing.B, newInstance func([]byte) common.Wa
 	}
 }
 
-func BenchmarkAddRequestHeaderV2_wasmer(b *testing.B) {
-	benchmarkAddRequestHeaderV2(b, wasmer.NewInstanceFromBinary)
+func BenchmarkAddRequestHeaderV2_wazero(b *testing.B) {
+	benchmarkAddRequestHeaderV2(b, wazero.NewInstanceFromBinary)
 }
 
 func benchmarkAddRequestHeaderV2(b *testing.B, newInstance func([]byte) common.WasmInstance) {

--- a/internal/e2e/benchmark_wasmer_test.go
+++ b/internal/e2e/benchmark_wasmer_test.go
@@ -18,46 +18,26 @@
  * limitations under the License.
  */
 
-package wasmer
+package e2e
 
 import (
-	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
-	"mosn.io/mosn/pkg/log"
+	"testing"
 
-	"mosn.io/proxy-wasm-go-host/proxywasm/common"
+	"mosn.io/proxy-wasm-go-host/wasmer"
 )
 
-type VM struct {
-	engine *wasmerGo.Engine
-	store  *wasmerGo.Store
+func BenchmarkStartABIContextV1_wasmer(b *testing.B) {
+	benchmarkStartABIContextV1(b, wasmer.NewInstanceFromBinary)
 }
 
-func NewWasmerVM() common.WasmVM {
-	vm := &VM{}
-	vm.Init()
-
-	return vm
+func BenchmarkAddRequestHeaderV1_wasmer(b *testing.B) {
+	benchmarkAddRequestHeaderV1(b, wasmer.NewInstanceFromBinary)
 }
 
-func (w *VM) Name() string {
-	return "wasmer"
+func BenchmarkStartABIContextV2_wasmer(b *testing.B) {
+	benchmarkStartABIContextV2(b, wasmer.NewInstanceFromBinary)
 }
 
-func (w *VM) Init() {
-	w.engine = wasmerGo.NewEngine()
-	w.store = wasmerGo.NewStore(w.engine)
-}
-
-func (w *VM) NewModule(wasmBytes []byte) common.WasmModule {
-	if len(wasmBytes) == 0 {
-		return nil
-	}
-
-	m, err := wasmerGo.NewModule(w.store, wasmBytes)
-	if err != nil {
-		log.DefaultLogger.Errorf("[wasmer][vm] fail to new module, err: %v", err)
-		return nil
-	}
-
-	return NewWasmerModule(w, m, wasmBytes)
+func BenchmarkAddRequestHeaderV2_wasmer(b *testing.B) {
+	benchmarkAddRequestHeaderV2(b, wasmer.NewInstanceFromBinary)
 }

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-package wasm
+package e2e
 
 import (
 	_ "embed"
@@ -23,14 +23,20 @@ import (
 	"strconv"
 	"testing"
 
+	"mosn.io/pkg/log"
+
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
 	v2 "mosn.io/proxy-wasm-go-host/proxywasm/v2"
-	"mosn.io/proxy-wasm-go-host/wasmer"
+	"mosn.io/proxy-wasm-go-host/wazero"
 )
 
-func TestStartABIContextV1_wasmer(t *testing.T) {
-	testStartABIContextV1(t, wasmer.NewInstanceFromBinary)
+func init() {
+	log.DefaultLogger.SetLogLevel(log.ERROR)
+}
+
+func TestStartABIContextV1_wazero(t *testing.T) {
+	testStartABIContextV1(t, wazero.NewInstanceFromBinary)
 }
 
 func testStartABIContextV1(t *testing.T, newInstance func([]byte) common.WasmInstance) {
@@ -58,8 +64,8 @@ func startABIContextV1(instance common.WasmInstance) (wasmCtx *v1.ABIContext, er
 	return
 }
 
-func TestAddRequestHeaderV1_wasmer(t *testing.T) {
-	instance := wasmer.NewInstanceFromBinary(binAddRequestHeaderV1)
+func TestAddRequestHeaderV1_wazero(t *testing.T) {
+	instance := wazero.NewInstanceFromBinary(binAddRequestHeaderV1)
 	defer instance.Stop()
 	testV1(t, instance, testAddRequestHeaderV1)
 }
@@ -132,8 +138,8 @@ func (im *headersHandlerV1) GetHttpRequestHeader() common.HeaderMap {
 	return im.reqHeader
 }
 
-func TestStartABIContextV2_wasmer(t *testing.T) {
-	testStartABIContextV2(t, wasmer.NewInstanceFromBinary)
+func TestStartABIContextV2_wazero(t *testing.T) {
+	testStartABIContextV2(t, wazero.NewInstanceFromBinary)
 }
 
 func testStartABIContextV2(t *testing.T, newInstance func([]byte) common.WasmInstance) {
@@ -161,8 +167,8 @@ func startABIContextV2(instance common.WasmInstance) (wasmCtx *v2.ABIContext, er
 	return
 }
 
-func TestAddRequestHeaderV2_wasmer(t *testing.T) {
-	instance := wasmer.NewInstanceFromBinary(binAddRequestHeaderV2)
+func TestAddRequestHeaderV2_wazero(t *testing.T) {
+	instance := wazero.NewInstanceFromBinary(binAddRequestHeaderV2)
 	defer instance.Stop()
 	testV2(t, instance, testAddRequestHeaderV2)
 }

--- a/internal/e2e/e2e_wasmer_test.go
+++ b/internal/e2e/e2e_wasmer_test.go
@@ -18,46 +18,31 @@
  * limitations under the License.
  */
 
-package wasmer
+package e2e
 
 import (
-	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
-	"mosn.io/mosn/pkg/log"
+	_ "embed"
+	"testing"
 
-	"mosn.io/proxy-wasm-go-host/proxywasm/common"
+	"mosn.io/proxy-wasm-go-host/wasmer"
 )
 
-type VM struct {
-	engine *wasmerGo.Engine
-	store  *wasmerGo.Store
+func TestStartABIContextV1_wasmer(t *testing.T) {
+	testStartABIContextV1(t, wasmer.NewInstanceFromBinary)
 }
 
-func NewWasmerVM() common.WasmVM {
-	vm := &VM{}
-	vm.Init()
-
-	return vm
+func TestStartABIContextV2_wasmer(t *testing.T) {
+	testStartABIContextV2(t, wasmer.NewInstanceFromBinary)
 }
 
-func (w *VM) Name() string {
-	return "wasmer"
+func TestAddRequestHeaderV1_wasmer(t *testing.T) {
+	instance := wasmer.NewInstanceFromBinary(binAddRequestHeaderV1)
+	defer instance.Stop()
+	testV1(t, instance, testAddRequestHeaderV1)
 }
 
-func (w *VM) Init() {
-	w.engine = wasmerGo.NewEngine()
-	w.store = wasmerGo.NewStore(w.engine)
-}
-
-func (w *VM) NewModule(wasmBytes []byte) common.WasmModule {
-	if len(wasmBytes) == 0 {
-		return nil
-	}
-
-	m, err := wasmerGo.NewModule(w.store, wasmBytes)
-	if err != nil {
-		log.DefaultLogger.Errorf("[wasmer][vm] fail to new module, err: %v", err)
-		return nil
-	}
-
-	return NewWasmerModule(w, m, wasmBytes)
+func TestAddRequestHeaderV2_wasmer(t *testing.T) {
+	instance := wasmer.NewInstanceFromBinary(binAddRequestHeaderV2)
+	defer instance.Stop()
+	testV2(t, instance, testAddRequestHeaderV2)
 }

--- a/internal/e2e/testdata.go
+++ b/internal/e2e/testdata.go
@@ -1,4 +1,4 @@
-package wasm
+package e2e
 
 import (
 	"fmt"

--- a/wasmer/api.go
+++ b/wasmer/api.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -14,6 +17,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package wasmer
 
 import (

--- a/wasmer/debug.go
+++ b/wasmer/debug.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wasmer/debug_test.go
+++ b/wasmer/debug_test.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wasmer/instance.go
+++ b/wasmer/instance.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wasmer/instance_test.go
+++ b/wasmer/instance_test.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wasmer/module.go
+++ b/wasmer/module.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wasmer/types.go
+++ b/wasmer/types.go
@@ -1,3 +1,6 @@
+//go:build wasmer
+// +build wasmer
+
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with

--- a/wazero/api.go
+++ b/wazero/api.go
@@ -1,6 +1,3 @@
-//go:build wasmer
-// +build wasmer
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,46 +15,18 @@
  * limitations under the License.
  */
 
-package wasmer
+package wazero
 
 import (
-	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
-	"mosn.io/mosn/pkg/log"
-
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 )
 
-type VM struct {
-	engine *wasmerGo.Engine
-	store  *wasmerGo.Store
-}
+func NewInstanceFromBinary(wasmBytes []byte) common.WasmInstance {
+	vm := NewVM()
 
-func NewWasmerVM() common.WasmVM {
-	vm := &VM{}
-	vm.Init()
+	module := vm.NewModule(wasmBytes)
 
-	return vm
-}
+	instance := module.NewInstance()
 
-func (w *VM) Name() string {
-	return "wasmer"
-}
-
-func (w *VM) Init() {
-	w.engine = wasmerGo.NewEngine()
-	w.store = wasmerGo.NewStore(w.engine)
-}
-
-func (w *VM) NewModule(wasmBytes []byte) common.WasmModule {
-	if len(wasmBytes) == 0 {
-		return nil
-	}
-
-	m, err := wasmerGo.NewModule(w.store, wasmBytes)
-	if err != nil {
-		log.DefaultLogger.Errorf("[wasmer][vm] fail to new module, err: %v", err)
-		return nil
-	}
-
-	return NewWasmerModule(w, m, wasmBytes)
+	return instance
 }

--- a/wazero/instance.go
+++ b/wazero/instance.go
@@ -1,0 +1,343 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package wazero
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/api"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"mosn.io/mosn/pkg/log"
+
+	importsv1 "mosn.io/proxy-wasm-go-host/internal/imports/v1"
+	importsv2 "mosn.io/proxy-wasm-go-host/internal/imports/v2"
+	"mosn.io/proxy-wasm-go-host/proxywasm/common"
+	v1 "mosn.io/proxy-wasm-go-host/proxywasm/v1"
+	v2 "mosn.io/proxy-wasm-go-host/proxywasm/v2"
+)
+
+var (
+	ErrInstanceNotStart     = errors.New("instance has not started")
+	ErrInstanceAlreadyStart = errors.New("instance has already started")
+)
+
+type Instance struct {
+	vm     *VM
+	module *Module
+
+	instance api.Module
+
+	lock     sync.Mutex
+	started  uint32
+	refCount int
+	stopCond *sync.Cond
+
+	// user-defined data
+	data interface{}
+}
+
+type InstanceOptions func(instance *Instance)
+
+func NewInstance(vm *VM, module *Module, options ...InstanceOptions) *Instance {
+	r := vm.runtime
+
+	ins := &Instance{
+		vm:     vm,
+		module: module,
+		lock:   sync.Mutex{},
+	}
+	ins.stopCond = sync.NewCond(&ins.lock)
+
+	for _, option := range options {
+		option(ins)
+	}
+
+	if _, err := wasi_snapshot_preview1.Instantiate(ctx, r); err != nil {
+		_ = r.Close(ctx)
+		log.DefaultLogger.Warnf("[wazero][instance] NewInstance fail to create wasi_snapshot_preview1 env, err: %v", err)
+		panic(err)
+	}
+
+	// Instantiate WASI also under the unstable name for old compilers,
+	// such as TinyGo 0.19 used for v1 ABI.
+	wasiBuilder := r.NewHostModuleBuilder("wasi_unstable")
+	wasi_snapshot_preview1.NewFunctionExporter().ExportFunctions(wasiBuilder)
+	if _, err := wasiBuilder.Instantiate(ctx, r); err != nil {
+		log.DefaultLogger.Warnf("[wazero][instance] NewInstance fail to create wasi_unstable env, err: %v", err)
+		_ = r.Close(ctx)
+		panic(err)
+	}
+
+	return ins
+}
+
+func (i *Instance) GetData() interface{} {
+	return i.data
+}
+
+func (i *Instance) SetData(data interface{}) {
+	i.data = data
+}
+
+func (i *Instance) Acquire() bool {
+	i.lock.Lock()
+	defer i.lock.Unlock()
+
+	if !i.checkStart() {
+		return false
+	}
+
+	i.refCount++
+
+	return true
+}
+
+func (i *Instance) Release() {
+	i.lock.Lock()
+	i.refCount--
+
+	if i.refCount <= 0 {
+		i.stopCond.Broadcast()
+	}
+	i.lock.Unlock()
+}
+
+func (i *Instance) Lock(data interface{}) {
+	i.lock.Lock()
+	i.data = data
+}
+
+func (i *Instance) Unlock() {
+	i.data = nil
+	i.lock.Unlock()
+}
+
+func (i *Instance) GetModule() common.WasmModule {
+	return i.module
+}
+
+func (i *Instance) Start() error {
+	ctx := context.Background()
+
+	ins, err := i.vm.runtime.InstantiateModule(ctx, i.module.module, wazero.NewModuleConfig())
+	if err != nil {
+		log.DefaultLogger.Errorf("[wazero][instance] Start failed to instantiate module, err: %v", err)
+		i.vm.runtime.Close(ctx)
+		return err
+	}
+
+	i.instance = ins
+
+	atomic.StoreUint32(&i.started, 1)
+
+	return nil
+}
+
+func (i *Instance) Stop() {
+	go func() {
+		i.lock.Lock()
+		for i.refCount > 0 {
+			i.stopCond.Wait()
+		}
+		i.vm.runtime.Close(context.Background())
+		_ = atomic.CompareAndSwapUint32(&i.started, 1, 0)
+		i.lock.Unlock()
+	}()
+}
+
+// return true is Instance is started, false if not started.
+func (i *Instance) checkStart() bool {
+	return atomic.LoadUint32(&i.started) == 1
+}
+
+func (i *Instance) RegisterImports(abiName string) error {
+	if i.checkStart() {
+		log.DefaultLogger.Errorf("[wazero][instance] RegisterFunc not allow to register func after instance started, abiName: %s",
+			abiName)
+		return ErrInstanceAlreadyStart
+	}
+
+	// proxy-wasm cannot run multiple ABI in the same instance because the ABI
+	// collides. They all use the same module name: "env"
+	module := "env"
+
+	var hostFunctions func(common.WasmInstance) map[string]interface{}
+	switch abiName {
+	case v1.ProxyWasmABI_0_1_0:
+		hostFunctions = importsv1.HostFunctions
+	case v2.ProxyWasmABI_0_2_0:
+		hostFunctions = importsv2.HostFunctions
+	default:
+		return fmt.Errorf("unknown ABI: %s", abiName)
+	}
+
+	b := i.vm.runtime.NewHostModuleBuilder(module)
+	for n, f := range hostFunctions(i) {
+		b.NewFunctionBuilder().WithFunc(f).Export(n)
+	}
+
+	if _, err := b.Instantiate(ctx, i.vm.runtime); err != nil {
+		log.DefaultLogger.Errorf("[wazero][instance] RegisterImports failed to instantiate ABI %s, err: %v", abiName, err)
+		return err
+	}
+	return nil
+}
+
+func (i *Instance) Malloc(size int32) (uint64, error) {
+	if !i.checkStart() {
+		return 0, ErrInstanceNotStart
+	}
+
+	malloc, err := i.GetExportsFunc("malloc")
+	if err != nil {
+		return 0, err
+	}
+
+	addr, err := malloc.Call(size)
+	if err != nil {
+		i.HandleError(err)
+		return 0, err
+	}
+
+	return uint64(addr.(int32)), nil
+}
+
+func (i *Instance) GetExportsFunc(funcName string) (common.WasmFunction, error) {
+	if !i.checkStart() {
+		return nil, ErrInstanceNotStart
+	}
+
+	wf := i.instance.ExportedFunction(funcName)
+	f := &wasmFunction{fn: wf}
+	if rts := wf.Definition().ResultTypes(); len(rts) > 0 {
+		f.rt = rts[0]
+	}
+	return f, nil
+}
+
+type wasmFunction struct {
+	fn api.Function
+	rt api.ValueType
+}
+
+// Call implements common.WasmFunction
+func (f *wasmFunction) Call(args ...interface{}) (interface{}, error) {
+	realArgs := make([]uint64, 0, len(args))
+	for _, a := range args {
+		switch a := a.(type) {
+		case int32:
+			realArgs = append(realArgs, api.EncodeI32(a))
+		case int64:
+			realArgs = append(realArgs, api.EncodeI64(a))
+		default:
+			panic(fmt.Errorf("unexpected arg type %v", a))
+		}
+	}
+	if ret, err := f.fn.Call(ctx, realArgs...); err != nil {
+		return nil, err
+	} else if len(ret) == 0 {
+		return nil, nil
+	} else {
+		v := ret[0]
+		switch f.rt {
+		case api.ValueTypeI32:
+			return int32(v), nil
+		case api.ValueTypeI64:
+			return int64(v), nil
+		default:
+			panic(fmt.Errorf("unexpected result type %v", f.rt))
+		}
+	}
+}
+
+func (i *Instance) GetExportsMem(memName string) ([]byte, error) {
+	if !i.checkStart() {
+		return nil, ErrInstanceNotStart
+	}
+
+	ctx := context.Background()
+	size := i.instance.ExportedMemory(memName).Size(ctx) * 65536
+	return i.GetMemory(0, uint64(size))
+}
+
+func (i *Instance) GetMemory(addr uint64, size uint64) ([]byte, error) {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	ret, ok := mem.Read(ctx, uint32(addr), uint32(size))
+	if !ok { // unexpected
+		return nil, fmt.Errorf("unable to read %d bytes", size)
+	}
+	return ret, nil
+}
+
+func (i *Instance) PutMemory(addr uint64, size uint64, content []byte) error {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	ok := mem.Write(ctx, uint32(addr), content[0:size])
+	if !ok {
+		return errors.New("out of memory")
+	}
+	return nil
+}
+
+func (i *Instance) GetByte(addr uint64) (byte, error) {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	b, ok := mem.ReadByte(ctx, uint32(addr))
+	if !ok {
+		return b, errors.New("out of memory")
+	}
+	return b, nil
+}
+
+func (i *Instance) PutByte(addr uint64, b byte) error {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	ok := mem.WriteByte(ctx, uint32(addr), b)
+	if !ok {
+		return errors.New("out of memory")
+	}
+	return nil
+}
+
+func (i *Instance) GetUint32(addr uint64) (uint32, error) {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	n, ok := mem.ReadUint32Le(ctx, uint32(addr))
+	if !ok {
+		return n, errors.New("out of memory")
+	}
+	return n, nil
+}
+
+func (i *Instance) PutUint32(addr uint64, value uint32) error {
+	ctx := context.Background()
+	mem := i.instance.Memory()
+	ok := mem.WriteUint32Le(ctx, uint32(addr), value)
+	if !ok {
+		return errors.New("out of memory")
+	}
+	return nil
+}
+
+func (i *Instance) HandleError(error) {}

--- a/wazero/module.go
+++ b/wazero/module.go
@@ -1,6 +1,3 @@
-//go:build wasmer
-// +build wasmer
-
 /*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
@@ -18,46 +15,40 @@
  * limitations under the License.
  */
 
-package wasmer
+package wazero
 
 import (
-	wasmerGo "github.com/wasmerio/wasmer-go/wasmer"
-	"mosn.io/mosn/pkg/log"
+	wazero "github.com/tetratelabs/wazero"
 
 	"mosn.io/proxy-wasm-go-host/proxywasm/common"
 )
 
-type VM struct {
-	engine *wasmerGo.Engine
-	store  *wasmerGo.Store
+type Module struct {
+	vm          *VM
+	module      wazero.CompiledModule
+	abiNameList []string
+	rawBytes    []byte
 }
 
-func NewWasmerVM() common.WasmVM {
-	vm := &VM{}
-	vm.Init()
-
-	return vm
-}
-
-func (w *VM) Name() string {
-	return "wasmer"
-}
-
-func (w *VM) Init() {
-	w.engine = wasmerGo.NewEngine()
-	w.store = wasmerGo.NewStore(w.engine)
-}
-
-func (w *VM) NewModule(wasmBytes []byte) common.WasmModule {
-	if len(wasmBytes) == 0 {
-		return nil
+func NewModule(vm *VM, module wazero.CompiledModule, wasmBytes []byte) *Module {
+	m := &Module{
+		vm:       vm,
+		module:   module,
+		rawBytes: wasmBytes,
 	}
 
-	m, err := wasmerGo.NewModule(w.store, wasmBytes)
-	if err != nil {
-		log.DefaultLogger.Errorf("[wasmer][vm] fail to new module, err: %v", err)
-		return nil
-	}
+	m.Init()
 
-	return NewWasmerModule(w, m, wasmBytes)
+	return m
+}
+
+func (w *Module) Init() {
+}
+
+func (w *Module) NewInstance() common.WasmInstance {
+	return NewInstance(w.vm, w)
+}
+
+func (w *Module) GetABINameList() []string {
+	return nil
 }


### PR DESCRIPTION
This makes wasmer use the same `wasmer` build flag as mosn does, to prevent it from being built-in by default.

This enables wazero by default, using a non-tagged version until the end of the month when using `wasi_unstable` is configurable in the next version.

```
BenchmarkStartABIContextV1_wazero
BenchmarkStartABIContextV1_wazero-16     	      73	  13924962 ns/op
BenchmarkAddRequestHeaderV1_wazero
BenchmarkAddRequestHeaderV1_wazero-16    	  145736	      7260 ns/op
BenchmarkStartABIContextV2_wazero
BenchmarkStartABIContextV2_wazero-16     	      88	  13720664 ns/op
BenchmarkAddRequestHeaderV2_wazero
BenchmarkAddRequestHeaderV2_wazero-16    	  164587	      7250 ns/op
BenchmarkStartABIContextV1_wasmer
BenchmarkStartABIContextV1_wasmer-16     	     225	   8061989 ns/op
BenchmarkAddRequestHeaderV1_wasmer
BenchmarkAddRequestHeaderV1_wasmer-16    	   75734	     15168 ns/op
BenchmarkStartABIContextV2_wasmer
BenchmarkStartABIContextV2_wasmer-16     	      79	  13223690 ns/op
BenchmarkAddRequestHeaderV2_wasmer
BenchmarkAddRequestHeaderV2_wasmer-16    	   77937	     16036 ns/op
```

Fixes #15