### PR TITLE
deps: updates wazero to 1.0.0-pre.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a
-	github.com/tetratelabs/wazero v1.0.0-pre.4
+	github.com/tetratelabs/wazero v1.0.0-pre.6
 	github.com/wasmerio/wasmer-go v1.0.4
 	mosn.io/mosn v1.2.0
 	mosn.io/pkg v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a h1:P0R3+CTAT7daT8ig5gh9GEd/eDQ5md1xl4pkYMcwOqg=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
-github.com/tetratelabs/wazero v1.0.0-pre.4 h1:RBJQT5OzmORkSp6MmZDWoFEr0zXjk4pmvMKAdeUnsaI=
-github.com/tetratelabs/wazero v1.0.0-pre.4/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
+github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/wazero/instance.go
+++ b/wazero/instance.go
@@ -300,15 +300,13 @@ func (i *Instance) GetExportsMem(memName string) ([]byte, error) {
 		return nil, ErrInstanceNotStart
 	}
 
-	ctx := context.Background()
 	mem := i.instance.ExportedMemory(memName)
-	return i.GetMemory(0, uint64(mem.Size(ctx)))
+	return i.GetMemory(0, uint64(mem.Size()))
 }
 
 func (i *Instance) GetMemory(addr uint64, size uint64) ([]byte, error) {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	ret, ok := mem.Read(ctx, uint32(addr), uint32(size))
+	ret, ok := mem.Read(uint32(addr), uint32(size))
 	if !ok { // unexpected
 		return nil, fmt.Errorf("[wazero][instance] GetMemory unable to read %d bytes", size)
 	}
@@ -316,9 +314,8 @@ func (i *Instance) GetMemory(addr uint64, size uint64) ([]byte, error) {
 }
 
 func (i *Instance) PutMemory(addr uint64, size uint64, content []byte) error {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	ok := mem.Write(ctx, uint32(addr), content[0:size])
+	ok := mem.Write(uint32(addr), content[0:size])
 	if !ok {
 		return errors.New("out of memory")
 	}
@@ -326,9 +323,8 @@ func (i *Instance) PutMemory(addr uint64, size uint64, content []byte) error {
 }
 
 func (i *Instance) GetByte(addr uint64) (byte, error) {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	b, ok := mem.ReadByte(ctx, uint32(addr))
+	b, ok := mem.ReadByte(uint32(addr))
 	if !ok {
 		return b, errors.New("out of memory")
 	}
@@ -336,9 +332,8 @@ func (i *Instance) GetByte(addr uint64) (byte, error) {
 }
 
 func (i *Instance) PutByte(addr uint64, b byte) error {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	ok := mem.WriteByte(ctx, uint32(addr), b)
+	ok := mem.WriteByte(uint32(addr), b)
 	if !ok {
 		return errors.New("out of memory")
 	}
@@ -346,9 +341,8 @@ func (i *Instance) PutByte(addr uint64, b byte) error {
 }
 
 func (i *Instance) GetUint32(addr uint64) (uint32, error) {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	n, ok := mem.ReadUint32Le(ctx, uint32(addr))
+	n, ok := mem.ReadUint32Le(uint32(addr))
 	if !ok {
 		return n, errors.New("out of memory")
 	}
@@ -356,9 +350,8 @@ func (i *Instance) GetUint32(addr uint64) (uint32, error) {
 }
 
 func (i *Instance) PutUint32(addr uint64, value uint32) error {
-	ctx := context.Background()
 	mem := i.instance.Memory()
-	ok := mem.WriteUint32Le(ctx, uint32(addr), value)
+	ok := mem.WriteUint32Le(uint32(addr), value)
 	if !ok {
 		return errors.New("out of memory")
 	}


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.6](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.6).

Notably, v1.0.0-pre.6:
* improves module compilation and initialization performance

The following features aren't used here, but could be in the future.
* adds `writefs.NewDirFS` which lets you add new files.
  * `path_open` `O_CREAT` flags, `path_remove_directory` `path_rename` `path_unlink_file`
* adds `NewFilesystemLoggingListenerFactory` with dramatically improved logging.

This also includes changes described in [1.0.0-pre.5](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.5). Notably, context param was removed from memory functions as it was never used due to the scope being very narrow, and adds overhead to propagate.