### PR TITLE
deps: updates wazero to 1.0.0-pre.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a
-	github.com/tetratelabs/wazero v1.0.0-pre.6
+	github.com/tetratelabs/wazero v1.0.0-pre.8
 	github.com/wasmerio/wasmer-go v1.0.4
 	mosn.io/mosn v1.2.0
 	mosn.io/pkg v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a h1:P0R3+CTAT7daT8ig5gh9GEd/eDQ5md1xl4pkYMcwOqg=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
-github.com/tetratelabs/wazero v1.0.0-pre.6 h1:3DRqjuHazHyZmgWCgqu7nKgYIYNEi2+2RQpCwTqbVHs=
-github.com/tetratelabs/wazero v1.0.0-pre.6/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
+github.com/tetratelabs/wazero v1.0.0-pre.8 h1:Ir82PWj79WCppH+9ny73eGY2qv+oCnE3VwMY92cBSyI=
+github.com/tetratelabs/wazero v1.0.0-pre.8/go.mod h1:u8wrFmpdrykiFK0DFPiFm5a4+0RzsdmXYVtijBKqUVo=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=

--- a/wazero/module.go
+++ b/wazero/module.go
@@ -18,6 +18,7 @@
 package wazero
 
 import (
+	"context"
 	"strings"
 
 	wazero "github.com/tetratelabs/wazero"
@@ -27,14 +28,16 @@ import (
 
 type Module struct {
 	vm          *VM
+	runtime     wazero.Runtime
 	module      wazero.CompiledModule
 	abiNameList []string
 	rawBytes    []byte
 }
 
-func NewModule(vm *VM, module wazero.CompiledModule, wasmBytes []byte) *Module {
+func NewModule(vm *VM, runtime wazero.Runtime, module wazero.CompiledModule, wasmBytes []byte) *Module {
 	m := &Module{
 		vm:       vm,
+		runtime:  runtime,
 		module:   module,
 		rawBytes: wasmBytes,
 	}
@@ -45,6 +48,10 @@ func NewModule(vm *VM, module wazero.CompiledModule, wasmBytes []byte) *Module {
 }
 
 func (w *Module) Init() {
+}
+
+func (w *Module) Close(ctx context.Context) {
+	w.runtime.Close(ctx)
 }
 
 func (w *Module) NewInstance() common.WasmInstance {


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0-pre.8](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0-pre.8) which notably
* Better supports WASI including third-party integrated tests
* Adds support for writeable filesystems via FSConfig
* Improves observability with LogScopes, e.g. filesystem.
* Obviates Namespace in favor of cheaper Runtimes sharing a CompilationCache

Signed-off-by: Edoardo Vacchi <evacchi@users.noreply.github.com>
