### PR TITLE
chore: upgrade Go requirement to 1.18

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module mosn.io/proxy-wasm-go-host
 
-go 1.17
+go 1.18
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
The 1.17 is not supported after adding wazero.
And it is not tested in the CI:
https://github.com/mosn/proxy-wasm-go-host/blob/65d402ad5059342a16416a8f4ceee97c2f89a10a/.github/workflows/workflow.yml#L63