### PR TITLE
deps: updates wazero to 1.2.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/stretchr/testify v1.8.0
 	github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a
-	github.com/tetratelabs/wazero v1.0.0-rc.2
+	github.com/tetratelabs/wazero v1.2.1
 	github.com/wasmerio/wasmer-go v1.0.4
 	mosn.io/mosn v1.2.0
 	mosn.io/pkg v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69
 github.com/tebeka/strftime v0.1.3/go.mod h1:7wJm3dZlpr4l/oVK0t1HYIc4rMzQ2XJlOMIUJUJH6XQ=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a h1:P0R3+CTAT7daT8ig5gh9GEd/eDQ5md1xl4pkYMcwOqg=
 github.com/tetratelabs/wabin v0.0.0-20220927005300-3b0fbf39a46a/go.mod h1:m9ymHTgNSEjuxvw8E7WWe4Pl4hZQHXONY8wE6dMLaRk=
-github.com/tetratelabs/wazero v1.0.0-rc.2 h1:OA3UUynnoqxrjCQ94mpAtdO4/oMxFQVNL2BXDMOc66Q=
-github.com/tetratelabs/wazero v1.0.0-rc.2/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.2.1 h1:J4X2hrGzJvt+wqltuvcSjHQ7ujQxA9gb6PeMs4qlUWs=
+github.com/tetratelabs/wazero v1.2.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20200427203606-3cfed13b9966/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.2.1](https://github.com/tetratelabs/wazero/releases/tag/v1.2.1) which improves performance and support for non-blocking I/O.

```
goos: darwin
goarch: arm64
pkg: mosn.io/proxy-wasm-go-host/internal/e2e
                             │ v1.0.0-rc.2.txt │             v1.2.1.txt              │
                             │     sec/op      │    sec/op     vs base               │
StartABIContextV1_wazero-12       3.118m ±  8%   1.242m ±  4%  -60.15% (p=0.002 n=6)
AddRequestHeaderV1_wazero-12      3.751µ ±  3%   3.468µ ± 33%        ~ (p=0.065 n=6)
StartABIContextV2_wazero-12       3.345m ±  3%   1.375m ±  3%  -58.90% (p=0.002 n=6)
AddRequestHeaderV2_wazero-12      3.823µ ±  5%   5.038µ ± 26%  +31.79% (p=0.002 n=6)
```