### PR TITLE
Allow setting wazero module configuration

### DIFF
--- a/wazero/instance.go
+++ b/wazero/instance.go
@@ -64,6 +64,12 @@ type Instance struct {
 
 type InstanceOptions func(instance *Instance)
 
+func InstanceWithConfig(config wazero.ModuleConfig) InstanceOptions {
+	return func(instance *Instance) {
+		instance.config = config
+	}
+}
+
 func NewInstance(vm *VM, module *Module, options ...InstanceOptions) *Instance {
 	// Here, we initialize an empty runtime as imports are defined prior to start.
 	ins := &Instance{

--- a/wazero/instance.go
+++ b/wazero/instance.go
@@ -51,6 +51,7 @@ type Instance struct {
 	runtime  wazero.Runtime
 	instance api.Module
 	abiList  []types.ABI
+	config   wazero.ModuleConfig
 
 	lock     sync.Mutex
 	started  uint32
@@ -69,6 +70,7 @@ func NewInstance(vm *VM, module *Module, options ...InstanceOptions) *Instance {
 		vm:      vm,
 		module:  module,
 		runtime: wazero.NewRuntimeWithConfig(ctx, vm.config),
+		config:  wazero.NewModuleConfig(),
 		lock:    sync.Mutex{},
 	}
 
@@ -144,7 +146,7 @@ func (i *Instance) Start() error {
 		abi.OnInstanceCreate(i)
 	}
 
-	ins, err := r.Instantiate(ctx, i.module.rawBytes)
+	ins, err := r.InstantiateWithConfig(ctx, i.module.rawBytes, i.config)
 	if err != nil {
 		r.Close(ctx)
 		log.DefaultLogger.Errorf("[wazero][instance] Start failed to instantiate module, err: %v", err)


### PR DESCRIPTION
This allows for setting critical wazero module configuration. For example, to use the host time:

```

import (
    "github.com/tetratelabs/wazero"
    wazeroHost "mosn.io/proxy-wasm-go-host/wazero"
)

...

// compile the wasm module
module := vm.NewModule(wasmBytes)

// create a new instance
instance = module.NewInstance()

// configure wazero module environment
conf := wazero.NewModuleConfig().WithSysWalltime().WithSysNanotime()

// set wazero config
wazeroHost.InstanceWithConfig(conf)(instance.(*wazeroHost.Instance))

// proceed as usual

...

```
	
	